### PR TITLE
VPS-998 | Adds support for eml account renewal | Adam Poulton

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -130,3 +130,10 @@ const (
 	StateCancelled  TxnState = "cancelled"
 	StateReversed   TxnState = "reversed"
 )
+
+type CommunicateMethod string
+
+const (
+	CommunicateMethodSMS   CommunicateMethod = "sms"
+	CommunicateMethodEmail CommunicateMethod = "email"
+)

--- a/eml_store_test.go
+++ b/eml_store_test.go
@@ -2,9 +2,10 @@ package eml
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -13,19 +14,20 @@ const (
 	baseUrl      = "https://eml.com"
 	clientId     = "client"
 	clientSecret = "secret"
+	accessToken  = "aToken"
 )
 
 var ctx = context.Background()
 
 func mockTokenResponse(t *testing.T) {
 	httpmock.RegisterResponder("POST", "https://eml.com/3.0/token", func(req *http.Request) (*http.Response, error) {
-		bodyBytes, _ := ioutil.ReadAll(req.Body)
+		bodyBytes, _ := io.ReadAll(req.Body)
 		assert.Equal(t, "grant_type=client_credentials", string(bodyBytes), "Malformed token body %s", string(bodyBytes))
 		acceptHeader := req.Header.Get("Accept")
 		assert.Equal(t, "application/vnd.eml+json", acceptHeader, "expected eml vendor accept content type, got %s", acceptHeader)
 		authHeader := req.Header.Get("Authorization")
 		assert.Equal(t, "Basic Y2xpZW50OnNlY3JldA==", authHeader, "expected basic auth header, got %s", authHeader)
-		return httpmock.NewJsonResponse(200, TokenResponse{AccessToken: "aToken", TokenType: "bearer", ExpiresIn: 60 * 60})
+		return httpmock.NewJsonResponse(200, TokenResponse{AccessToken: accessToken, TokenType: "bearer", ExpiresIn: 60 * 60})
 	})
 }
 
@@ -44,7 +46,7 @@ func Test_emlStore_GetAccount(t *testing.T) {
 		contentTypeHeader := req.Header.Get("Content-Type")
 		assert.Equal(t, "application/vnd.eml+json", contentTypeHeader, "expected eml vendor content type, got %s", contentTypeHeader)
 		authHeader := req.Header.Get("Authorization")
-		assert.Equal(t, "Bearer aToken", authHeader, "expected bearer aToken auth header, got %s", authHeader)
+		assert.Equal(t, "Bearer "+accessToken, authHeader, "expected bearer %s auth header, got %s", accessToken, authHeader)
 		return httpmock.NewJsonResponse(200, accSummary)
 	})
 
@@ -52,7 +54,7 @@ func Test_emlStore_GetAccount(t *testing.T) {
 		acceptHeader := req.Header.Get("Accept")
 		assert.Equal(t, "application/vnd.eml+json", acceptHeader, "expected eml vendor accept content type, got %s", acceptHeader)
 		authHeader := req.Header.Get("Authorization")
-		assert.Equal(t, "Bearer aToken", authHeader, "expected bearer aToken auth header, got %s", authHeader)
+		assert.Equal(t, "Bearer "+accessToken, authHeader, "expected bearer %s auth header, got %s", accessToken, authHeader)
 		return httpmock.NewJsonResponse(200, AccountInfo{AccountSummary: accSummary, AccountId: "eaid"})
 	})
 
@@ -68,4 +70,214 @@ func Test_emlStore_GetAccount(t *testing.T) {
 	info := httpmock.GetCallCountInfo()
 	tokenCalls := info["POST https://eml.com/3.0/token"]
 	assert.Equal(t, 1, tokenCalls, "Expected 1 token call, got %d", tokenCalls)
+}
+
+// Test the complete renewal flow: authenticate -> initiate -> activate
+func Test_emlStore_RenewalFlow(t *testing.T) {
+	e := &Settings{EmlRestId: clientId, EmlHostUrl: baseUrl}
+	store := &emlStore{_restSecret: clientSecret, _env: e}
+	store.lazyInit(ctx)
+
+	httpmock.ActivateNonDefault(store._lazyClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+	mockTokenResponse(t)
+
+	// Mock authenticate endpoint
+	authResponse := &AuthenticateResponse{
+		TokenID:      "token123",
+		EmailAddress: "test@example.com",
+		Mobile:       "+61412345678",
+	}
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/authenticate", func(req *http.Request) (*http.Response, error) {
+		// Verify headers
+		contentTypeHeader := req.Header.Get("Content-Type")
+		assert.Equal(t, "application/vnd.eml+json", contentTypeHeader, "expected eml vendor content type, got %s", contentTypeHeader)
+		authHeader := req.Header.Get("Authorization")
+		assert.Equal(t, "Bearer "+accessToken, authHeader, "expected bearer %s auth header, got %s", accessToken, authHeader)
+
+		// Verify request body
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var authReq AuthenticateRequest
+		err := json.Unmarshal(bodyBytes, &authReq)
+		assert.NoError(t, err, "failed to unmarshal authenticate request")
+		assert.Equal(t, "app123", authReq.ApplicationID, "expected application_id = app123, got %s", authReq.ApplicationID)
+		assert.Equal(t, "192.168.1.1", authReq.IPAddress, "expected ip_address = 192.168.1.1, got %s", authReq.IPAddress)
+
+		return httpmock.NewJsonResponse(200, authResponse)
+	})
+
+	// Mock initiate endpoint
+	initiateResponse := &InitiateResponse{
+		OperationID: "op456",
+	}
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/initiate", func(req *http.Request) (*http.Response, error) {
+		// Verify headers
+		contentTypeHeader := req.Header.Get("Content-Type")
+		assert.Equal(t, "application/vnd.eml+json", contentTypeHeader, "expected eml vendor content type, got %s", contentTypeHeader)
+
+		// Verify request body
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var initiateReq InitiateRequest
+		err := json.Unmarshal(bodyBytes, &initiateReq)
+		assert.NoError(t, err, "failed to unmarshal initiate request")
+		assert.Equal(t, "192.168.1.1", initiateReq.IPAddress, "expected ip_address = 192.168.1.1, got %s", initiateReq.IPAddress)
+		assert.Equal(t, "token123", initiateReq.TokenID, "expected token_id = token123, got %s", initiateReq.TokenID)
+		assert.Equal(t, CommunicateMethodSMS, initiateReq.CommunicateMethod, "expected communicate_method = sms, got %s", initiateReq.CommunicateMethod)
+		assert.Equal(t, "renewal", initiateReq.OperationType, "expected operation_type = renewal, got %s", initiateReq.OperationType)
+
+		return httpmock.NewJsonResponse(200, initiateResponse)
+	})
+
+	// Mock activate endpoint
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/activate", func(req *http.Request) (*http.Response, error) {
+		// Verify headers
+		contentTypeHeader := req.Header.Get("Content-Type")
+		assert.Equal(t, "application/vnd.eml+json", contentTypeHeader, "expected eml vendor content type, got %s", contentTypeHeader)
+
+		// Verify request body
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var activateReq ActivateRequest
+		err := json.Unmarshal(bodyBytes, &activateReq)
+		assert.NoError(t, err, "failed to unmarshal activate request")
+		assert.Equal(t, "op456", activateReq.ValidationData.OperationID, "expected operation_id = op456, got %s", activateReq.ValidationData.OperationID)
+		assert.Equal(t, "123456", activateReq.ValidationData.SecurityCode, "expected security_code = 123456, got %s", activateReq.ValidationData.SecurityCode)
+		assert.Equal(t, "192.168.1.1", activateReq.ValidationData.IPAddress, "expected ip_address = 192.168.1.1, got %s", activateReq.ValidationData.IPAddress)
+		assert.NotNil(t, activateReq.EnablePlastic, "expected enable_plastic to be set")
+		assert.Equal(t, "true", *activateReq.EnablePlastic, "expected enable_plastic = true, got %s", *activateReq.EnablePlastic)
+
+		return httpmock.NewStringResponse(200, ""), nil
+	})
+
+	// Execute the full flow
+	authReq := AuthenticateRequest{
+		ApplicationID: "app123",
+		IPAddress:     "192.168.1.1",
+	}
+	authResp, err := store.Authenticate(ctx, "eaid123", authReq)
+	assert.NoError(t, err, "error authenticating %v", err)
+	assert.Equal(t, "token123", authResp.TokenID, "expected token_id = token123, got %s", authResp.TokenID)
+	assert.Equal(t, "test@example.com", authResp.EmailAddress, "expected email = test@example.com, got %s", authResp.EmailAddress)
+
+	initiateReq := InitiateRequest{
+		IPAddress:         "192.168.1.1",
+		TokenID:           authResp.TokenID,
+		CommunicateMethod: CommunicateMethodSMS,
+		OperationType:     "renewal",
+	}
+	initiateResp, err := store.Initiate(ctx, "eaid123", initiateReq)
+	assert.NoError(t, err, "error initiating %v", err)
+	assert.Equal(t, "op456", initiateResp.OperationID, "expected operation_id = op456, got %s", initiateResp.OperationID)
+
+	activateReq := ActivateRequest{
+		ValidationData: ValidationData{
+			OperationID:  initiateResp.OperationID,
+			SecurityCode: "123456",
+			IPAddress:    "192.168.1.1",
+		},
+		EnablePlastic: BoolToStringPtr(true),
+	}
+	err = store.Activate(ctx, "eaid123", activateReq)
+	assert.NoError(t, err, "error activating %v", err)
+
+	// Verify call counts
+	assert.Equal(t, 4, httpmock.GetTotalCallCount(), "Expected 4 calls (1 token + 3 renewals), got %d", httpmock.GetTotalCallCount())
+	info := httpmock.GetCallCountInfo()
+	tokenCalls := info["POST https://eml.com/3.0/token"]
+	assert.Equal(t, 1, tokenCalls, "Expected 1 token call, got %d", tokenCalls)
+}
+
+// Test initiate with email communication method
+func Test_emlStore_InitiateWithEmail(t *testing.T) {
+	e := &Settings{EmlRestId: clientId, EmlHostUrl: baseUrl}
+	store := &emlStore{_restSecret: clientSecret, _env: e}
+	store.lazyInit(ctx)
+
+	httpmock.ActivateNonDefault(store._lazyClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+	mockTokenResponse(t)
+
+	initiateResponse := &InitiateResponse{OperationID: "op789"}
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/initiate", func(req *http.Request) (*http.Response, error) {
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var initiateReq InitiateRequest
+		err := json.Unmarshal(bodyBytes, &initiateReq)
+		assert.NoError(t, err, "failed to unmarshal initiate request")
+		assert.Equal(t, CommunicateMethodEmail, initiateReq.CommunicateMethod, "expected communicate_method = email, got %s", initiateReq.CommunicateMethod)
+
+		return httpmock.NewJsonResponse(200, initiateResponse)
+	})
+
+	initiateReq := InitiateRequest{
+		IPAddress:         "10.0.0.1",
+		TokenID:           "token456",
+		CommunicateMethod: CommunicateMethodEmail,
+		OperationType:     "renewal",
+	}
+	resp, err := store.Initiate(ctx, "eaid123", initiateReq)
+	assert.NoError(t, err, "error initiating with email %v", err)
+	assert.Equal(t, "op789", resp.OperationID, "expected operation_id = op789, got %s", resp.OperationID)
+}
+
+// Test activate without enable_plastic (should be omitted from JSON)
+func Test_emlStore_ActivateWithoutPlastic(t *testing.T) {
+	e := &Settings{EmlRestId: clientId, EmlHostUrl: baseUrl}
+	store := &emlStore{_restSecret: clientSecret, _env: e}
+	store.lazyInit(ctx)
+
+	httpmock.ActivateNonDefault(store._lazyClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+	mockTokenResponse(t)
+
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/activate", func(req *http.Request) (*http.Response, error) {
+		bodyBytes, _ := io.ReadAll(req.Body)
+		var activateReq ActivateRequest
+		err := json.Unmarshal(bodyBytes, &activateReq)
+		assert.NoError(t, err, "failed to unmarshal activate request")
+		assert.Nil(t, activateReq.EnablePlastic, "expected enable_plastic to be nil/omitted")
+
+		// Verify the raw JSON doesn't contain enable_plastic
+		bodyStr := string(bodyBytes)
+		assert.NotContains(t, bodyStr, "enable_plastic", "enable_plastic should be omitted from JSON when nil")
+
+		return httpmock.NewStringResponse(200, ""), nil
+	})
+
+	activateReq := ActivateRequest{
+		ValidationData: ValidationData{
+			OperationID:  "op123",
+			SecurityCode: "654321",
+			IPAddress:    "172.16.0.1",
+		},
+		// EnablePlastic is nil, should be omitted
+	}
+	err := store.Activate(ctx, "eaid123", activateReq)
+	assert.NoError(t, err, "error activating without plastic %v", err)
+}
+
+// Test error handling for renewal endpoints
+func Test_emlStore_RenewalErrorHandling(t *testing.T) {
+	e := &Settings{EmlRestId: clientId, EmlHostUrl: baseUrl}
+	store := &emlStore{_restSecret: clientSecret, _env: e}
+	store.lazyInit(ctx)
+
+	httpmock.ActivateNonDefault(store._lazyClient.GetClient())
+	defer httpmock.DeactivateAndReset()
+	mockTokenResponse(t)
+
+	// Mock error response
+	errorResponse := &ErrorModel{
+		Code:        "invalid_request",
+		Description: "Invalid application ID",
+	}
+	httpmock.RegisterResponder("POST", "https://eml.com/3.0/accounts/eaid123/authenticate", func(req *http.Request) (*http.Response, error) {
+		return httpmock.NewJsonResponse(400, errorResponse)
+	})
+
+	authReq := AuthenticateRequest{
+		ApplicationID: "invalid",
+		IPAddress:     "192.168.1.1",
+	}
+	_, err := store.Authenticate(ctx, "eaid123", authReq)
+	assert.Error(t, err, "expected error for invalid authentication")
+	assert.Contains(t, err.Error(), "invalid_request", "expected error to contain error code")
 }

--- a/helpers.go
+++ b/helpers.go
@@ -84,3 +84,14 @@ func (e *emlStore) refreshToken(ctx context.Context) error {
 	e.token = mapBearerToken(resp.Result().(*TokenResponse))
 	return nil
 }
+
+func StringPtr(s string) *string {
+	return &s
+}
+
+func BoolToStringPtr(b bool) *string {
+	if b {
+		return StringPtr("true")
+	}
+	return StringPtr("false")
+}

--- a/models.go
+++ b/models.go
@@ -395,3 +395,36 @@ type TxnEvent struct {
 	/* The balance on the account after the event. */
 	RunningBalance TxnCurrency `json:"running_balance"`
 }
+
+type AuthenticateRequest struct {
+	ApplicationID string `json:"application_id"`
+	IPAddress     string `json:"ip_address"`
+}
+
+type AuthenticateResponse struct {
+	TokenID      string `json:"token_id"`
+	EmailAddress string `json:"email_address"`
+	Mobile       string `json:"mobile"`
+}
+
+type InitiateRequest struct {
+	IPAddress         string            `json:"ip_address"`
+	TokenID           string            `json:"token_id"`
+	CommunicateMethod CommunicateMethod `json:"communicate_method"`
+	OperationType     string            `json:"operation_type"`
+}
+
+type InitiateResponse struct {
+	OperationID string `json:"operation_id"`
+}
+
+type ValidationData struct {
+	OperationID  string `json:"operation_id"`
+	SecurityCode string `json:"security_code"`
+	IPAddress    string `json:"ip_address"`
+}
+
+type ActivateRequest struct {
+	ValidationData ValidationData `json:"validation_data"`
+	EnablePlastic  *string        `json:"enable_plastic,omitempty"`
+}


### PR DESCRIPTION
Adds support for the eml account renewal flow endpoints

- `/accounts/{id}/authenticate`
- `/accounts/{id}/initiate`
- `/accounts/{id}/activate`